### PR TITLE
v3.0.0b2

### DIFF
--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -11,9 +11,9 @@ export const UIConstants = {
 export const ConfigManagerConstants = {
     CURRENT_DATA_VERSION: 1,
     ARGON2_SALT_LENGTH: 16,
-    ARGON2_ROUNDS_NO_PW: 10,
-    ARGON2_ROUNDS_MIN: 400,
-    ARGON2_ROUNDS_MAX: 450
+    ARGON2_ROUNDS_NO_PW: 1,
+    ARGON2_ROUNDS_MIN: 20,
+    ARGON2_ROUNDS_MAX: 25
 };
 
 export const AppDataConstants = {
@@ -21,7 +21,7 @@ export const AppDataConstants = {
 }
 
 export const Argon2Constants = {
-    MEMORY_COST: 2048, // memoryCost: memory usage in KiB
+    MEMORY_COST: 65536, // memoryCost: memory usage in KiB
     PARALLELISM: 1,  // parallelism: degree of parallelism (controls parallel thread use)
     HASH_LEN: 32,  // hashLen: desired key length in bytes (32 bytes = 256 bits)
     KEY_LEN: 256,  // 256 bits

--- a/app/insertVersion.js
+++ b/app/insertVersion.js
@@ -1,3 +1,3 @@
-appVersion = "3.0.0b0";
+appVersion = "3.0.0b2";
 
 $(".version").text(appVersion);

--- a/app/services/EncryptionService.js
+++ b/app/services/EncryptionService.js
@@ -16,9 +16,9 @@ export class EncryptionService {
 
     // Mapping for argon2 iterations based on difficulty.
     this.argon2IterationMapping = {
-      low: 100,
-      middle: 400,
-      high: 800
+      low: 5,
+      middle: 20,
+      high: 40
     };
 
     // Mapping for salt lengths based on difficulty.

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
                                     to protect text, files, and passwords using
                                     <strong>AES-GCM</strong>
                                     and
-                                    <strong>Argon2 key derivation</strong>
+                                    <strong>Argon2id key derivation</strong>
                                     ; all happening securely in your browser.
                                 </p>
                                 <ol class="text-muted informationRow mb-3">
@@ -633,7 +633,7 @@
                                                     (if you know what you are doing).
                                                 </p>
                                                 <p>
-                                                    <i>By default, the site uses a random, secure 16-byte salt, 400 rounds and 2048KiB of algorithm memory on every encrypt action.</i>
+                                                    <i>By default, the site uses a random, secure 16-byte salt, 20 rounds and 64MiB of algorithm memory (Argon2id) on every encrypt action.</i>
                                                 </p>
                                             </blockquote>
                                         </div>
@@ -702,7 +702,7 @@
                                                 <b>all locally saved data (e.g. passwords, names, configs etc.)</b>
                                                 with a master password.
                                             </p>
-                                            <p>The encryption process uses AES-GCM and Argon2 with a random salt and 400+ Argon2 rounds. Don't close the windows while encrypting.</p>
+                                            <p>The encryption process uses AES-GCM and Argon2id with a random salt and 20 Argon2id rounds with 64MiB of memory. Don't close the windows while encrypting.</p>
                                             <p>
                                                 <b>Attention:</b>
                                                 If you forget your master password, you can't decrypt your app data anymore.
@@ -784,11 +784,11 @@
                                                 <br />
                                                 <span class="help-block">
                                                     <small>
-                                                        Low: 100 rounds
+                                                        Low: 5 rounds
                                                         <br />
-                                                        Middle: 400 rounds
+                                                        Middle: 20 rounds
                                                         <br />
-                                                        High: 800 rounds
+                                                        High: 40 rounds
                                                     </small>
                                                 </span>
                                             </p>

--- a/pages/developer-documentation-technical-information.html
+++ b/pages/developer-documentation-technical-information.html
@@ -39,6 +39,8 @@
 
         <!-- Icons css -->
         <link href="../assets/css/icons.min.css" rel="stylesheet" type="text/css" />
+
+        <link href="../assets/libs/highlightjs/highlightjs.min.css" rel="stylesheet" type="text/css" />
     </head>
 
     <body>
@@ -294,7 +296,7 @@
                                     </li>
                                     <li>
                                         <strong><code>antelle/argon2-browser</code></strong>
-                                        : Provides the Argon2d key derivation implementation for browsers <a href="https://github.com/antelle/argon2-browser">(GitHub)</a>.
+                                        : Provides the Argon2id key derivation implementation for browsers <a href="https://github.com/antelle/argon2-browser">(GitHub)</a>.
                                     </li>
                                 </ul>
                                 <p>
@@ -457,5 +459,16 @@
 
         <!-- App JS-->
         <script src="../app/insertVersion.js" defer></script>
+
+        <!-- Highlight.js -->
+        <script src="../assets/libs/highlightjs/highlightjs.min.js" defer></script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', (event) => {
+                document.querySelectorAll('.language-javascript').forEach((el) => {
+                    hljs.highlightElement(el);
+                });
+            });
+            </script>
     </body>
 </html>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -716,6 +716,11 @@
                                     <h4 class="faq-question">What are Argon2 rounds and salt, and how do they affect security?</h4>
                                     <p class="faq-answer mb-4">Round difficulty slow down key derivation to resist brute-force attacks, and salts add randomness to prevent the use of precomputed keys.</p>
                                 </div>
+                                <div>
+                                    <div class="faq-question-q-box">Q.</div>
+                                    <h4 class="faq-question">What Argon2 settings does the site use?</h4>
+                                    <p class="faq-answer mb-4">The site uses the Argon2id version of the algorithm, 64MiB of algorithm memory for every action and a parallelism of 1 due to JavaScript limitations.</p>
+                                </div>
                             </div>
                             <div class="col-lg-5">
                                 <!-- Q22 -->
@@ -728,13 +733,13 @@
                                 <div>
                                     <div class="faq-question-q-box">Q.</div>
                                     <h4 class="faq-question">What are the default cryptographic settings used?</h4>
-                                    <p class="faq-answer mb-4">By default, the app uses AES-GCM 256-bit encryption, Argon2 with 400 rounds, a 16-byte salt, and a new 12-byte nonce for each encryption.</p>
+                                    <p class="faq-answer mb-4">By default, the app uses AES-GCM 256-bit encryption, Argon2 with 20rounds, a 16-byte salt, and a new 12-byte nonce for each encryption.</p>
                                 </div>
                                 <!-- Q24 (placed in the right column as an extra item) -->
                                 <div>
                                     <div class="faq-question-q-box">Q.</div>
                                     <h4 class="faq-question">Can I customize the Argon2 settings and what do the levels mean?</h4>
-                                    <p class="faq-answer mb-4">Yes, you can choose between Low, Middle, and High presets for both round count (from 100 up to 800) and salt length (12 or 16 bytes), providing control over encryption strength and performance.</p>
+                                    <p class="faq-answer mb-4">Yes, you can choose between Low, Middle, and High presets for both round count (from 5 up to 40) and salt length (12 or 16 bytes), providing control over encryption strength and performance.</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Updated Security:
- Argon2id now uses 64MiB of memory with customizable options for 5-40 rounds, 1 round on unsecured local data and 20 rounds for secured local data

Visual Updates:
- Added code highlighting for dev documentation

Content Updates:
- Added information for argon2 algorithm on FAQ site