### PR TITLE
3.3.0: Breaking change: Cryptit no longer accepts unauthenticated header

### DIFF
--- a/app/insertVersion.js
+++ b/app/insertVersion.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const appVersion = "3.2.2";
+const appVersion = "3.3.0";
 
 function normalizeUrl(url) {
     return url.replace(/\/$/, "");

--- a/app/main/controllers/AppDataController.js
+++ b/app/main/controllers/AppDataController.js
@@ -357,7 +357,7 @@ export class AppDataController {
     Swal.fire({
       icon: 'warning',
       title: 'Clear all data?',
-      text: "All local data from main app v3 will be rewritten with default values. This action can't be undone.",
+      text: "All local data from the app will be overwritten with default values. This action can't be undone.",
       showCancelButton: true,
       confirmButtonText: '<i class="mdi mdi-delete me-1"></i> Clear',
       cancelButtonText: '<i class="mdi mdi-cancel me-1"></i>Cancel',

--- a/app/main/controllers/MainController.js
+++ b/app/main/controllers/MainController.js
@@ -56,7 +56,7 @@ export class MainController {
    */
   async initializeServices() {
     const confManager = await ConfigManager.create();
-    const cryptit = createCryptit({acceptUnauthenticatedHeader: true});
+    const cryptit = createCryptit();
 
     const fssOptions = {
       streamSaverMitmPath: './assets/libs/streamsaver/mitm.html',


### PR DESCRIPTION
- Payloads generated by version 3.0.0 and earlier are no longer supported.
-  Decryption of payloads created with version 3.0.0 and earlier will fail. To decrypt these payloads, use / download the last compatible release, v3.2.2.